### PR TITLE
Reduce required back button clicks with `replaceState`

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -137,7 +137,7 @@ class IndexPage extends Component {
     if (typeof window === 'undefined') {
       return
     }
-    window.history.pushState(
+    window.history.replaceState(
       undefined,
       '',
       linkPath(


### PR DESCRIPTION
## Overview

If you change your colors a number of times, then you have to use the back button an equal number of times to exit back out of the website. I think it would be a better experience if you only had to use the back button once to exit, regardless of how many changes you'd made.

This can be achieved by switching [`pushState`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to [`replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState) in `updatePath`.

## Testing

1. Open up the app and start making color changes. 
2. Note these color changes are reflected in the URL bar. 
3. Note that there are no new changes pushed to the browser's history stack
    - If you navigated directly to the app, the back button should be disabled
    - If you navigated to the app from another page, clicking the back button should take you to that page. 

---

Fixes #26 

Cheers! 